### PR TITLE
Feature/rtti

### DIFF
--- a/Source/Object/Actor/Actor.cpp
+++ b/Source/Object/Actor/Actor.cpp
@@ -7,6 +7,7 @@
 
 AActor::AActor() : Depth{ 0 }
 {
+	
 }
 
 void AActor::BeginPlay()

--- a/Source/Object/Actor/Actor.h
+++ b/Source/Object/Actor/Actor.h
@@ -11,6 +11,7 @@ class UWorld;
 
 class AActor : public UObject
 {
+    DECLARE_OBJECT(AActor, UObject)
 	friend class FEditorManager;
 public:
 	AActor();

--- a/Source/Object/Actor/Arrow.h
+++ b/Source/Object/Actor/Arrow.h
@@ -3,6 +3,7 @@
 
 class AArrow : public AActor
 {
+    DECLARE_OBJECT(AArrow, AActor)
 	using Super = AActor;
 
 public:

--- a/Source/Object/Actor/Camera.h
+++ b/Source/Object/Actor/Camera.h
@@ -17,6 +17,7 @@ namespace ECameraProjectionMode
 
 class ACamera : public AActor
 {
+    DECLARE_OBJECT(ACamera, AActor)
 
     using Super = AActor;
     

--- a/Source/Object/Actor/Cone.h
+++ b/Source/Object/Actor/Cone.h
@@ -3,6 +3,7 @@
 
 class ACone : public AActor
 {
+    DECLARE_OBJECT(ACone, AActor)
     using Super = AActor;
 public:
     ACone();

--- a/Source/Object/Actor/Cube.cpp
+++ b/Source/Object/Actor/Cube.cpp
@@ -19,6 +19,7 @@ void ACube::BeginPlay()
 void ACube::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
+    std::cout<<GetClassFName().ToString().ToStdString()<<std::endl;
 }
 
 const char* ACube::GetTypeName()

--- a/Source/Object/Actor/Cube.cpp
+++ b/Source/Object/Actor/Cube.cpp
@@ -9,6 +9,13 @@ ACube::ACube()
 	RootComponent = CubeComponent;
 
 	CubeComponent->SetRelativeTransform(FTransform());
+	std::cout << "ACube IsA AActor? " << IsA("AActor") << std::endl;
+	std::cout << "ACube IsA UObject? " << IsA("UObject") << std::endl;
+	std::cout << "ACube IsA ACube? " << IsA("ACube") << std::endl;
+	std::cout << "ACube IsA OtherClass? " << IsA("OtherClass") << std::endl;
+	//std::cout<<Super::GetClassFName().ToString().ToStdString()<<std::endl;
+	
+	//std::cout<<IsA(FName("UObject"))<<" "<<Super::IsA(FName("UObject"))<<std::endl;
 }
 
 void ACube::BeginPlay()
@@ -19,7 +26,6 @@ void ACube::BeginPlay()
 void ACube::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
-    std::cout<<GetClassFName().ToString().ToStdString()<<std::endl;
 }
 
 const char* ACube::GetTypeName()

--- a/Source/Object/Actor/Cube.cpp
+++ b/Source/Object/Actor/Cube.cpp
@@ -2,6 +2,7 @@
 #include <Object/PrimitiveComponent/UPrimitiveComponent.h>
 
 #include "Arrow.h"
+#include "Sphere.h"
 
 ACube::ACube()
 {
@@ -9,16 +10,7 @@ ACube::ACube()
 
 	UCubeComp* CubeComponent = AddComponent<UCubeComp>();
 	RootComponent = CubeComponent;
-
 	CubeComponent->SetRelativeTransform(FTransform());
-	std::cout<<StaticClassFName_Internal().ToString().ToStdString()<<" "<<std::endl;
-	std::cout << "ACube IsA AActor? " << IsA<AActor>()<<" "<<IsAByName("AActor") << std::endl;
-	std::cout << "ACube IsA UObject? " << IsA<UObject>() <<" "<<IsAByName("UObject") << std::endl;
-	std::cout << "ACube IsA ACube? " << IsA<ACube>() <<" "<<IsAByName("ACube") << std::endl;
-	std::cout << "ACube IsA OtherClass? " << IsA<AArrow>()<<" "<<IsAByName("AArrow")  << std::endl;
-	//std::cout<<Super::GetClassFName().ToString().ToStdString()<<std::endl;
-	
-	//std::cout<<IsA(FName("UObject"))<<" "<<Super::IsA(FName("UObject"))<<std::endl;
 }
 
 void ACube::BeginPlay()

--- a/Source/Object/Actor/Cube.cpp
+++ b/Source/Object/Actor/Cube.cpp
@@ -1,6 +1,8 @@
 ﻿#include "Cube.h"
 #include <Object/PrimitiveComponent/UPrimitiveComponent.h>
 
+#include "Arrow.h"
+
 ACube::ACube()
 {
 	bCanEverTick = true;
@@ -9,10 +11,11 @@ ACube::ACube()
 	RootComponent = CubeComponent;
 
 	CubeComponent->SetRelativeTransform(FTransform());
-	std::cout << "ACube IsA AActor? " << IsA("AActor") << std::endl;
-	std::cout << "ACube IsA UObject? " << IsA("UObject") << std::endl;
-	std::cout << "ACube IsA ACube? " << IsA("ACube") << std::endl;
-	std::cout << "ACube IsA OtherClass? " << IsA("OtherClass") << std::endl;
+	std::cout<<StaticClassFName_Internal().ToString().ToStdString()<<" "<<std::endl;
+	std::cout << "ACube IsA AActor? " << IsA<AActor>()<<" "<<IsAByName("AActor") << std::endl;
+	std::cout << "ACube IsA UObject? " << IsA<UObject>() <<" "<<IsAByName("UObject") << std::endl;
+	std::cout << "ACube IsA ACube? " << IsA<ACube>() <<" "<<IsAByName("ACube") << std::endl;
+	std::cout << "ACube IsA OtherClass? " << IsA<AArrow>()<<" "<<IsAByName("AArrow")  << std::endl;
 	//std::cout<<Super::GetClassFName().ToString().ToStdString()<<std::endl;
 	
 	//std::cout<<IsA(FName("UObject"))<<" "<<Super::IsA(FName("UObject"))<<std::endl;

--- a/Source/Object/Actor/Cube.h
+++ b/Source/Object/Actor/Cube.h
@@ -2,6 +2,7 @@
 #include "Actor.h"
 class ACube : public AActor
 {
+    DECLARE_OBJECT(ACube, AActor)
 	using Super = AActor;
 public:
 	ACube();

--- a/Source/Object/Actor/Cylinder.h
+++ b/Source/Object/Actor/Cylinder.h
@@ -3,6 +3,7 @@
 
 class ACylinder : public AActor
 {
+    DECLARE_OBJECT(ACylinder, AActor)
     using Super = AActor;
 public:
     ACylinder();

--- a/Source/Object/Actor/Picker.h
+++ b/Source/Object/Actor/Picker.h
@@ -4,6 +4,7 @@
 
 class APicker : public AActor
 {
+    DECLARE_OBJECT(APicker, AActor)
     using Super = AActor;
 public:
     APicker();

--- a/Source/Object/Actor/Sphere.h
+++ b/Source/Object/Actor/Sphere.h
@@ -3,6 +3,7 @@
 
 class ASphere : public AActor
 {
+    DECLARE_OBJECT(ASphere, AActor)
 	using Super = AActor;
 public:
 	ASphere();

--- a/Source/Object/ActorComponent/ActorComponent.h
+++ b/Source/Object/ActorComponent/ActorComponent.h
@@ -5,6 +5,7 @@
 class UActorComponent : public UObject
 {
 public:
+    DECLARE_OBJECT(UActorComponent, UObject)
 	UActorComponent() = default;
 
 	virtual void BeginPlay();

--- a/Source/Object/ObjectFactory.h
+++ b/Source/Object/ObjectFactory.h
@@ -19,7 +19,7 @@ public:
     static T* ConstructObject()
     {
         UE_LOG("DEBUG: Construct %s Object", typeid(T).name());
-
+        
         constexpr size_t ObjectSize = sizeof(T);
         void* RawMemory = FPlatformMemory::Malloc<EAT_Object>(ObjectSize);
 

--- a/Source/Object/UObject.cpp
+++ b/Source/Object/UObject.cpp
@@ -2,7 +2,6 @@
 
 UObject::UObject()
 {
-
 }
 
 UObject::~UObject()

--- a/Source/Object/UObject.h
+++ b/Source/Object/UObject.h
@@ -1,21 +1,33 @@
 ﻿#pragma once
 #include <memory>
 #include "Core/HAL/PlatformType.h"
+#include "Core/Name/FName.h"
 
 
 // TODO: RTTI 구현하면 enable_shared_from_this 제거
-class UObject : public std::enable_shared_from_this<UObject>
+class UObject/* : public std::enable_shared_from_this<UObject>*/
 {
 	friend class FObjectFactory;
 
 	uint32 UUID = 0;
 	uint32 InternalIndex; // Index of GUObjectArray
-
+protected:
+	static FName StaticClassFName_Internal() { return "UObject"; }
 public:
 	UObject();
 	virtual ~UObject();
-
+public:
+	virtual FName GetClassFName() const { return StaticClassFName_Internal(); }
+	bool IsA(FName ClassName) const { return GetClassFName() == ClassName; }
+	bool IsA(const UObject* Other) const { return Other && GetClassFName() == Other->GetClassFName(); }
+	
 public:
 	uint32 GetUUID() const { return UUID; }
 	uint32 GetInternalIndex() const { return InternalIndex; }
 };
+// 자동 RTTI 매크로 (UObject 하위 클래스 전부 자동 적용)
+#define DECLARE_OBJECT(ClassName, ParentClass) \
+public: \
+using Super = ParentClass; \
+static FName StaticClassFName_Internal() { return #ClassName; } \
+virtual FName GetClassFName() const override { return StaticClassFName_Internal(); }

--- a/Source/Object/UObject.h
+++ b/Source/Object/UObject.h
@@ -22,7 +22,12 @@ public:
 	static FName GetParentClassFName() { return StaticClassFName_Internal(); }
 	//virtual const UObject* GetParentClass() const { return nullptr; }
 
-	static bool IsA(FName ClassName){if (ClassName==GetClassFName())return true;return false;}
+	static bool IsAByName(FName ClassName){if (ClassName==GetClassFName())return true;return false;}
+	template<typename T>
+	bool IsA() const
+	{
+		return this->IsAByName(T::GetClassFName());
+	}
 public:
 	uint32 GetUUID() const { return UUID; }
 	uint32 GetInternalIndex() const { return InternalIndex; }
@@ -34,9 +39,11 @@ using Super = ParentClass; \
 static FName StaticClassFName_Internal() { return #ClassName; } \
 static FName GetClassFName() { return StaticClassFName_Internal(); } \
 static FName GetParentClassFName() { return Super::StaticClassFName_Internal(); } \
-static bool IsA(FName ClassName) \
+static bool IsAByName(FName ClassName) \
 { \
 if (GetClassFName() == ClassName) \
 return true; \
-return Super::IsA(ClassName); \
-}
+return Super::IsAByName(ClassName); \
+}\
+template<typename T> \
+bool IsA() const { return this->IsAByName(T::StaticClassFName_Internal()); }

--- a/Source/Object/UObject.h
+++ b/Source/Object/UObject.h
@@ -7,6 +7,7 @@
 // TODO: RTTI 구현하면 enable_shared_from_this 제거
 class UObject/* : public std::enable_shared_from_this<UObject>*/
 {
+	//DECLARE_OBJECT(UObject, UObject)
 	friend class FObjectFactory;
 
 	uint32 UUID = 0;
@@ -17,10 +18,11 @@ public:
 	UObject();
 	virtual ~UObject();
 public:
-	virtual FName GetClassFName() const { return StaticClassFName_Internal(); }
-	bool IsA(FName ClassName) const { return GetClassFName() == ClassName; }
-	bool IsA(const UObject* Other) const { return Other && GetClassFName() == Other->GetClassFName(); }
-	
+	static FName GetClassFName() { return StaticClassFName_Internal(); }
+	static FName GetParentClassFName() { return StaticClassFName_Internal(); }
+	//virtual const UObject* GetParentClass() const { return nullptr; }
+
+	static bool IsA(FName ClassName){if (ClassName==GetClassFName())return true;return false;}
 public:
 	uint32 GetUUID() const { return UUID; }
 	uint32 GetInternalIndex() const { return InternalIndex; }
@@ -30,4 +32,11 @@ public:
 public: \
 using Super = ParentClass; \
 static FName StaticClassFName_Internal() { return #ClassName; } \
-virtual FName GetClassFName() const override { return StaticClassFName_Internal(); }
+static FName GetClassFName() { return StaticClassFName_Internal(); } \
+static FName GetParentClassFName() { return Super::StaticClassFName_Internal(); } \
+static bool IsA(FName ClassName) \
+{ \
+if (GetClassFName() == ClassName) \
+return true; \
+return Super::IsA(ClassName); \
+}

--- a/Source/Object/UObject.h
+++ b/Source/Object/UObject.h
@@ -22,12 +22,14 @@ public:
 	static FName GetParentClassFName() { return StaticClassFName_Internal(); }
 	//virtual const UObject* GetParentClass() const { return nullptr; }
 
-	static bool IsAByName(FName ClassName){if (ClassName==GetClassFName())return true;return false;}
+//
 	template<typename T>
-	bool IsA() const
+		requires std::derived_from<T, UObject>
+	static bool IsA()
 	{
-		return this->IsAByName(T::GetClassFName());
+		return IsAByName(T::GetClassFName());
 	}
+	static bool IsA(FName ClassName){if (ClassName==GetClassFName())return true;return false;}
 public:
 	uint32 GetUUID() const { return UUID; }
 	uint32 GetInternalIndex() const { return InternalIndex; }
@@ -39,11 +41,12 @@ using Super = ParentClass; \
 static FName StaticClassFName_Internal() { return #ClassName; } \
 static FName GetClassFName() { return StaticClassFName_Internal(); } \
 static FName GetParentClassFName() { return Super::StaticClassFName_Internal(); } \
-static bool IsAByName(FName ClassName) \
+static bool IsA(FName ClassName) \
 { \
 if (GetClassFName() == ClassName) \
 return true; \
-return Super::IsAByName(ClassName); \
+return Super::IsA(ClassName); \
 }\
 template<typename T> \
-bool IsA() const { return this->IsAByName(T::StaticClassFName_Internal()); }
+requires std::derived_from<T, UObject>\
+static bool IsA() { return IsA(T::StaticClassFName_Internal()); }


### PR DESCRIPTION
RTTI 완성
RTTI 적용 원하는 오브젝트 헤더파일에
    DECLARE_OBJECT(ASphere, AActor)
입력 시 좌측을 자기자신, 우측을 부모로 인식하여 저장
UObject의 하위 개체만 RTTI 적용 가능
RTTI의 클래스 이름은 모두 FNAME로 관리

GetClassFName(): 현재 클래스의 이름
GetParentClassFName(): 부모 클래스의 이름
Super의 경우 부모 클래스의 별칭
Super::GetClassFName()와 같이 부모의 static 함수 실행 가능

IsA(FName): 입력받은 이름의 클래스가 현재 클래스의 부모 개체인지 재귀적으로 판별
즉 ACube에서 IsA(AActor, UObject, ACube) 모두 참 반환