### PR TITLE
Feature/viewmode toggle UI

### DIFF
--- a/Source/Core/Engine.cpp
+++ b/Source/Core/Engine.cpp
@@ -85,8 +85,8 @@ void UEngine::Initialize(
     InitializedScreenHeight = ScreenHeight;
     
     ui.Initialize(WindowHandle, *Renderer, ScreenWidth, ScreenHeight);
-    
-	UE_LOG("Engine Initialized!");
+    InitializeShowFlags();
+    UE_LOG("Engine Initialized!");
 }
 
 void UEngine::Run()
@@ -273,4 +273,56 @@ UObject* UEngine::GetObjectByUUID(uint32 InUUID) const
         return Obj->get();
     }
     return nullptr;
+}
+
+TMap<EEngineShowFlags, bool> UEngine::ShowFlagStates;
+
+void UEngine::InitializeShowFlags()
+{
+    ShowFlagStates.Add(EEngineShowFlags::SF_Primitives, true);
+    ShowFlagStates.Add(EEngineShowFlags::SF_Gizmo, true);
+    ShowFlagStates.Add(EEngineShowFlags::SF_BillboardText, true);
+}
+
+//  View Mode 변경
+void UEngine::SetViewMode(EViewModeIndex NewMode)
+{
+    ViewMode = NewMode;
+    // View Mode에 따른 셰이더 변경
+    if (ViewMode == EViewModeIndex::VMI_Wireframe)
+    {
+        Renderer->EnableWireframeMode();
+    }
+    else if (ViewMode == EViewModeIndex::VMI_Unlit)
+    {
+        Renderer->EnableUnlitMode();
+    }
+    else
+    {
+        Renderer->EnableLitMode();
+    }
+}
+
+//  Show Flag 설정
+void UEngine::SetShowFlag(EEngineShowFlags Flag, bool bEnable)
+{
+    ShowFlagStates[Flag] = bEnable;
+    //bShowPrimitives = bEnable;
+    //Renderer->SetShowPrimitives(bShowPrimitives); //  렌더러에 전달
+}
+
+//  Show Flag 상태 확인
+bool UEngine::IsShowFlagEnabled(EEngineShowFlags Flag) const
+{
+    if (Flag == EEngineShowFlags::SF_Primitives)
+    {
+        return ShowFlagStates[Flag];
+        //return bShowPrimitives;
+    }
+    return false;
+}
+
+const TMap<EEngineShowFlags, bool>& UEngine::GetShowFlagStates() const
+{
+    return ShowFlagStates;
 }

--- a/Source/Core/Engine.h
+++ b/Source/Core/Engine.h
@@ -11,14 +11,28 @@
 
 class UObject;
 class UWorld;
-
 enum class EScreenMode : uint8
 {
     Windowed,    // 창 모드
     Fullscreen,  // 전체화면 모드
     Borderless,  // 테두리 없는 창 모드
 };
+//View Mode (Lit, Unlit, Wireframe)
+enum class EViewModeIndex : uint32
+{
+    VMI_Lit,
+    VMI_Unlit,
+    VMI_Wireframe,
+};
 
+//Show Flag (프리미티브 렌더링 활성/비활성)
+enum class EEngineShowFlags : uint32
+{
+    SF_Primitives,
+    SF_Gizmo,
+    SF_BillboardText
+    
+};
 class UEngine : public TSingleton<UEngine>
 {
 public:
@@ -97,6 +111,21 @@ private:
 public:
     // TArray<std::shared_ptr<UObject>> GObjects;
     TMap<uint32, std::shared_ptr<UObject>> GObjects;
+public:
+    //View Mode 변경
+    void SetViewMode(EViewModeIndex NewMode);
+    EViewModeIndex GetViewMode() const { return ViewMode; }
+
+    void InitializeShowFlags();
+    //Show Flag 토글
+    void SetShowFlag(EEngineShowFlags Flag, bool bEnable);
+    bool IsShowFlagEnabled(EEngineShowFlags Flag) const;
+    const TMap<EEngineShowFlags, bool>& GetShowFlagStates() const;
+
+private:
+    EViewModeIndex ViewMode = EViewModeIndex::VMI_Lit;
+    //bool bShowPrimitives = true;
+    static TMap<EEngineShowFlags, bool> ShowFlagStates;
 };
 
 template <typename ObjectType> requires std::derived_from<ObjectType, UObject>

--- a/Source/Core/Rendering/UI.cpp
+++ b/Source/Core/Rendering/UI.cpp
@@ -504,24 +504,31 @@ void UI::RenderSettingsPanel()
 {
     ImGui::Begin("Render Settings");
 
-    //  View Mode 선택
+    // 2개의 컬럼 생성 (가운데 세로줄 포함)
+    ImGui::Columns(2, nullptr, true);
+
+    //첫 번째 컬럼 (View Mode 및 Grid Spacing)
+    ImGui::Text("View Mode");
+    ImGui::NextColumn(); // 다음 컬럼 이동
+
+    //두 번째 컬럼 (Show Flags)
+    ImGui::Text("Show Flags");
+    ImGui::NextColumn(); // 다음 컬럼 이동
+
+    //View Mode 드롭다운 (좌측 컬럼)
+    ImGui::PushItemWidth(-1);
     static const char* ViewModeNames[] = { "Lit", "Unlit", "Wireframe" };
     static int CurrentViewMode = static_cast<int>(UEngine::Get().GetViewMode());
 
-    if (ImGui::Combo("View Mode", &CurrentViewMode, ViewModeNames, IM_ARRAYSIZE(ViewModeNames)))
+    if (ImGui::Combo("##ViewMode", &CurrentViewMode, ViewModeNames, IM_ARRAYSIZE(ViewModeNames)))
     {
         UEngine::Get().SetViewMode(static_cast<EViewModeIndex>(CurrentViewMode));
     }
+    ImGui::PopItemWidth();
+    ImGui::NextColumn();
 
-    //  Show Flag 토글
-    /*
-    static bool bShowPrimitives = UEngine::Get().IsShowFlagEnabled(EEngineShowFlags::SF_Primitives);
-    if (ImGui::Checkbox("Show Primitives", &bShowPrimitives))
-    {
-        UEngine::Get().SetShowFlag(EEngineShowFlags::SF_Primitives,bShowPrimitives);
-    }*/
-    const auto& ShowFlagStates = UEngine::Get().GetShowFlagStates(); // ✅ 엔진에서 상태 가져오기
-
+    //Show Flag 체크박스 (우측 컬럼)
+    const auto& ShowFlagStates = UEngine::Get().GetShowFlagStates();
     for (auto& [Flag, bEnabled] : ShowFlagStates)
     {
         const char* FlagName = nullptr;
@@ -545,5 +552,21 @@ void UI::RenderSettingsPanel()
             UEngine::Get().SetShowFlag(Flag, bChecked);
         }
     }
+
+    //체크박스 목록 아래 가로 구분선 추가
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    //Grid Spacing UI (양쪽 컬럼을 합쳐 넓게 표시)
+    ImGui::Columns(1); // 컬럼 분할 해제 → 전체 너비 사용
+
+    static float GridSpacing = 10.0f; //임시 변수 (나중에 실제 값으로 변경 필요)
+    
+    ImGui::Text("Grid Spacing");
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(-1);
+    ImGui::SliderFloat("##GridSpacing", &GridSpacing, 1.0f, 100.0f, "%.1f");
+
     ImGui::End();
 }

--- a/Source/Core/Rendering/UI.h
+++ b/Source/Core/Rendering/UI.h
@@ -28,6 +28,8 @@ public:// UIWindows
     void RenderCameraSettings();
     void RenderPropertyWindow();
 	void RenderSceneManager();
+	void RenderSettingsPanel();
+
 private:
 	// Mouse 전용
 	ImVec2 ResizeToScreenByCurrentRatio(const ImVec2& vec2) const

--- a/Source/Core/Rendering/URenderer.cpp
+++ b/Source/Core/Rendering/URenderer.cpp
@@ -869,3 +869,24 @@ const void URenderer::ApplyCurrentRasterizerState() const
         }
     }
 }
+
+bool URenderer::ShouldRenderActor(const AActor* OwnerActor)
+{
+    if (!OwnerActor) return false;
+    const auto& ShowFlags = UEngine::Get().GetShowFlagStates();
+
+    //Primitives 비활성화 + Gizmo가 아닌 경우 렌더링 X
+    if (!ShowFlags[EEngineShowFlags::SF_Primitives] && !OwnerActor->IsGizmoActor()) 
+        return false;
+
+    //Gizmo 비활성화 + Gizmo인 경우 렌더링 X
+    if (!ShowFlags[EEngineShowFlags::SF_Gizmo] && OwnerActor->IsGizmoActor()) 
+        return false;
+    /*
+    //BillboardText 비활성화 + BillboardText인 경우 렌더링 X
+    if (!ShowFlags[EEngineShowFlags::SF_BillboardText] && OwnerActor->IsBillboardTextActor()) 
+        return false;
+    */
+
+    return true;
+}

--- a/Source/Core/Rendering/URenderer.h
+++ b/Source/Core/Rendering/URenderer.h
@@ -220,6 +220,10 @@ public:
 	void EnableLitMode();
 	void EnableUnlitMode();
 	const void ApplyCurrentRasterizerState() const;
+
+	//렌더링 여부 반환
+	static bool ShouldRenderActor(const AActor* OwnerActor);
+
 private:
 	ID3D11RasterizerState* WireframeRasterizerState = nullptr;
 	ID3D11RasterizerState* SolidRasterizerState = nullptr;

--- a/Source/Core/Rendering/URenderer.h
+++ b/Source/Core/Rendering/URenderer.h
@@ -213,5 +213,16 @@ public:
 
 	void RenderPickingTexture();
 	FMatrix GetProjectionMatrix() const { return ProjectionMatrix; }
+
+public:
+	//View Mode 변경 함수
+	void EnableWireframeMode();
+	void EnableLitMode();
+	void EnableUnlitMode();
+	const void ApplyCurrentRasterizerState() const;
+private:
+	ID3D11RasterizerState* WireframeRasterizerState = nullptr;
+	ID3D11RasterizerState* SolidRasterizerState = nullptr;
 #pragma endregion picking
+
 };

--- a/Source/Object/World/World.cpp
+++ b/Source/Object/World/World.cpp
@@ -134,7 +134,9 @@ void UWorld::RenderMainTexture(URenderer& Renderer)
 	// 셰이더 변경 불가
 	Renderer.PrepareMain();
 	Renderer.PrepareMainShader();
-
+	//현재 View Mode 및 Show Flag 상태 가져오기
+	//EViewModeIndex CurrentViewMode = UEngine::Get().GetViewMode();
+	bool bShowPrimitives = UEngine::Get().IsShowFlagEnabled(EEngineShowFlags::SF_Primitives);
 	// 1. 같은 메쉬여도 배치 여부가 다를수 있다.
 	// 2. 다른 메쉬여도 같은 토폴로지, 같은 머터리얼과 셰이더, 트
 
@@ -146,6 +148,7 @@ void UWorld::RenderMainTexture(URenderer& Renderer)
 		TArray<UPrimitiveComponent*> BatchTargetComponents;
 		for (auto RenderComponent : RenderComponents)
 		{
+			if (!bShowPrimitives&&!RenderComponent->GetOwner()->IsGizmoActor())continue;
 			//TODO11
 			// 나쁜점 -> Render를 추상화해서 사용하는데 이걸 막음
 			if (RenderComponent->GetIsBatch() && RenderComponent->GetVisibleFlag())

--- a/Source/Object/World/World.cpp
+++ b/Source/Object/World/World.cpp
@@ -136,7 +136,7 @@ void UWorld::RenderMainTexture(URenderer& Renderer)
 	Renderer.PrepareMainShader();
 	//현재 View Mode 및 Show Flag 상태 가져오기
 	//EViewModeIndex CurrentViewMode = UEngine::Get().GetViewMode();
-	bool bShowPrimitives = UEngine::Get().IsShowFlagEnabled(EEngineShowFlags::SF_Primitives);
+    const auto& ShowFlagStates = UEngine::Get().GetShowFlagStates();
 	// 1. 같은 메쉬여도 배치 여부가 다를수 있다.
 	// 2. 다른 메쉬여도 같은 토폴로지, 같은 머터리얼과 셰이더, 트
 
@@ -148,8 +148,9 @@ void UWorld::RenderMainTexture(URenderer& Renderer)
 		TArray<UPrimitiveComponent*> BatchTargetComponents;
 		for (auto RenderComponent : RenderComponents)
 		{
-			if (!bShowPrimitives&&!RenderComponent->GetOwner()->IsGizmoActor())continue;
-			//TODO11
+			AActor* OwnerActor = RenderComponent->GetOwner();
+
+			if (!Renderer.ShouldRenderActor(OwnerActor)) continue;
 			// 나쁜점 -> Render를 추상화해서 사용하는데 이걸 막음
 			if (RenderComponent->GetIsBatch() && RenderComponent->GetVisibleFlag())
 			{
@@ -157,11 +158,11 @@ void UWorld::RenderMainTexture(URenderer& Renderer)
 			}
 			else
 			{
-				if (RenderComponent->GetOwner()->GetDepth() > 0)
+				if (OwnerActor->GetDepth() > 0)
 				{
 					continue;
 				}
-				uint32 depth = RenderComponent->GetOwner()->GetDepth();
+				uint32 depth = OwnerActor->GetDepth();
 				// RenderComponent->UpdateConstantDepth(Renderer, depth);
 				RenderComponent->Render();
 			}

--- a/imgui.ini
+++ b/imgui.ini
@@ -30,3 +30,7 @@ Size=354,322
 Pos=1,5
 Size=351,535
 
+[Window][Render Settings]
+Pos=765,12
+Size=443,235
+

--- a/imgui.ini
+++ b/imgui.ini
@@ -23,14 +23,14 @@ Pos=0,868
 Size=1203,253
 
 [Window][Properties]
-Pos=0,541
-Size=354,322
+Pos=0,242
+Size=335,620
 
 [Window][Scene Manager]
 Pos=1,5
-Size=351,535
+Size=338,238
 
 [Window][Render Settings]
-Pos=765,12
-Size=443,235
+Pos=791,7
+Size=412,249
 


### PR DESCRIPTION
아래 3개 메뉴가 포함된 RenderSettingsPanel() 구현
1. WireFrame, 일반 뷰 모드 토글 가능한 드롭다운 메뉴
2. Primative, Gizmo 중 원하는 오브젝트만 렌더링하도록 하는 메뉴
3. batch line 간격 설정하는 메뉴

flag, view 등의 열거형 정보는 Engine에서 관리
URenderer의 static 함수 static bool ShouldRenderActor(const AActor* OwnerActor)
를 사용하여 렌더링 여부 판별 가능

현재 World의 RenderMainTexture 함수에서 렌더링 여부 판별해서 특정 오브젝트 무시하는중